### PR TITLE
Exclude test files from published package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule EtsSelect.MixProject do
   defp package do
     [
       files: ~w(lib mix.exs README* CHANGELOG* LICENCE*),
+      exclude_patterns: [~r/.*_test.exs/, ~r/test_helper.exs/],
       licenses: ["MIT"],
       links: %{
         "Github" => @github_url,


### PR DESCRIPTION
There's generally no reason to include test files in the published package on hex.pm. Usually this is accomplished by having the tests in `test/` (which isn't included in the default `:files` option), but if the test files are in `lib/` then they need to be explicitly excluded (although I do wonder if it would make sense to have `[~r/.*_test.exs/]` as the default exclude configuration).

Here's the relevant docs: https://hexdocs.pm/hex/Mix.Tasks.Hex.Publish.html#module-package-configuration

I tested this with `--dry-run`:
```
> mix hex.publish --dry-run
Building ets_select 0.1.2
  App: ets_select
  Name: ets_select
  Files:
    lib
    lib/ets_select.ex
    mix.exs
    README.md
    CHANGELOG.md
    LICENCE
  Version: 0.1.2
  Build tools: mix
  Description: ETS match spec builder from a simple intuitive query language
  Licenses: MIT
  Links:
    Changelog: https://github.com/maxohq/ets_select/blob/main/CHANGELOG.md
    Github: https://github.com/maxohq/ets_select
  Elixir: ~> 1.17
```